### PR TITLE
Rebuild against mkl v2025

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -8,3 +8,5 @@ gpu_variant:
 # Only needed for cuda-11
 cudatoolkit:
   - 11.8
+mkl:
+  - 2025

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - thread_queue.patch
 
 build:
-  number: 0
+  number: 1
   # we currently only need this for pytorch GPU, which currently only uses this for linux-64.
   # Windows is theoretically possible but we haven't got the CMake CUDA support to work there yet.
   skip: True  # [not (linux and x86_64)]


### PR DESCRIPTION
magma 2.7.1 b1

**Destination channel:** defaults

### Links

- [PKG-7081](https://anaconda.atlassian.net/browse/PKG-7081)
- [Upstream repository](https://bitbucket.org/icl/magma/src/v2.7.1)
- [Upstream changelog/diff](https://bitbucket.org/icl/magma/src/v2.7.1/ReleaseNotes)
- Relevant dependency PRs:
  - AnacondaRecipes/intel_repack-feedstock#26
  - AnacondaRecipes/mkl-service-feedstock#6

### Explanation of changes:

- Bumped `mkl` version


[PKG-7081]: https://anaconda.atlassian.net/browse/PKG-7081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ