### PR TITLE
Magma 2.9 - enable aarch64

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -37,12 +37,16 @@ export CUDAFLAGS="${CUDAFLAGS} -Xfatbin -compress-all"
 export CUDAFLAGS="${CUDAFLAGS} -Wno-deprecated-gpu-targets"
 export CXXFLAGS="${CXXFLAGS} -Wno-deprecated-declarations"
 
-# Set MKL configuration (aligned with Windows)
-export MKLROOT=$PREFIX
-export BLA_VENDOR=Intel10_64lp
-
 mkdir build
 cd build
+
+CMAKE_EXTRA_ARGS=""
+if [[ "$(uname -m)" == "aarch64" ]]; then
+  CMAKE_EXTRA_ARGS="-DBLA_VENDOR=OpenBLAS"
+else
+  export MKLROOT=$PREFIX
+  CMAKE_EXTRA_ARGS="-DMAGMA_WITH_MKL:BOOL=ON -DMKLROOT=$MKLROOT -DBLA_VENDOR=Intel10_64lp"
+fi
 
 cmake $SRC_DIR \
   -G "Ninja" \
@@ -51,10 +55,8 @@ cmake $SRC_DIR \
   -DGPU_TARGET=$CUDA_ARCH_LIST \
   -DMAGMA_ENABLE_CUDA:BOOL=ON \
   -DUSE_FORTRAN:BOOL=OFF \
-  -DMAGMA_WITH_MKL:BOOL=ON \
-  -DMKLROOT=$MKLROOT \
-  -DBLA_VENDOR=$BLA_VENDOR \
   -DCMAKE_CUDA_SEPARABLE_COMPILATION:BOOL=OFF \
+  ${CMAKE_EXTRA_ARGS} \
   ${CMAKE_ARGS}
 
 # Build both magma and magma_sparse (unlike conda-forge which only builds magma_sparse)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,8 @@ build:
   number: 2
   skip: true  # [not (win or linux)]
   overlinking_ignore_patterns:
-    - "lib/libgomp.so*"  # [aarch64]
+    - "lib/libgomp.so*"    # [aarch64]
+    - "lib/libmagma*.so*"  # [aarch64]
 requirements:
   build:
     - {{ stdlib('c') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,8 +13,8 @@ source:
     - patches/cuda13_clockrate.patch
 
 build:
-  number: 1
-  skip: true  # [not ((win or linux) and x86_64)]
+  number: 2
+  skip: true  # [not (win or linux)]
 requirements:
   build:
     - {{ stdlib('c') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,14 +31,16 @@ requirements:
     - libcublas-dev                                          # [cuda_compiler_version != "None"]
     - libcusparse-dev                                        # [cuda_compiler_version != "None"]
 
-    - intel-openmp {{ mkl }}
-    - mkl {{ mkl }}
-    - mkl-include
+    - intel-openmp {{ mkl }}  # [x86_64]
+    - mkl {{ mkl }}  # [x86_64]
+    - mkl-include  # [x86_64]
     - mkl-devel {{ mkl }}  # [win]
+    - libopenblas  # [aarch64]
 
   run:
-    - intel-openmp {{ mkl }}
-    - mkl {{ mkl }}
+    - intel-openmp {{ mkl }}  # [x86_64]
+    - mkl {{ mkl }}  # [x86_64]
+    - libopenblas  # [aarch64]
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,8 @@ source:
 build:
   number: 2
   skip: true  # [not (win or linux)]
+  overlinking_ignore_patterns:
+    - "lib/libgomp.so*"  # [aarch64]
 requirements:
   build:
     - {{ stdlib('c') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,6 +41,7 @@ requirements:
     - intel-openmp {{ mkl }}  # [x86_64]
     - mkl {{ mkl }}  # [x86_64]
     - libopenblas  # [aarch64]
+    - libgomp  # [aarch64]
 
 test:
   commands:


### PR DESCRIPTION
**magma 2.9.0 (linux-aarch64)**

**Destination channel:** defaults

### Links
* Upstream repository: https://github.com/icl-utk-edu/magma
* Relevant dependency PRs:

### Explanation of changes:

* **Adds Linux aarch64 support.** The skip condition is broadened from `(win or linux) and x86_64` to `(win or linux)`, enabling aarch64 builds. Build number bumped to 2.
* **Architecture-conditional BLAS backend in `build.sh`:** On aarch64, cmake is configured with `-DBLA_VENDOR=OpenBLAS`. On x86_64, the existing MKL configuration is preserved (`MAGMA_WITH_MKL=ON`, `MKLROOT`, `BLA_VENDOR=Intel10_64lp`). The previously hardcoded MKL flags in the cmake invocation are replaced with a `${CMAKE_EXTRA_ARGS}` variable set per-architecture.
* **Dependency selectors in `meta.yaml`:** `intel-openmp`, `mkl`, and `mkl-include` are now gated to `# [x86_64]`. New aarch64-specific dependencies added: `libopenblas` (host + run) and `libgomp` (run).
* **Overlinking ignore patterns for aarch64:** `lib/libgomp.so*` and `lib/libmagma*.so*` are excluded from overlinking checks on aarch64.