### PR TITLE
Add openblas to build matrix on windows.

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -32,16 +32,16 @@ md build
 cd build
 if errorlevel 1 exit /b 1
 
-:: Set MKLROOT and CMAKE_PREFIX_PATH for MKL detection
-set "MKLROOT=%LIBRARY_PREFIX%"
 set "CMAKE_PREFIX_PATH=%LIBRARY_PREFIX%;%CMAKE_PREFIX_PATH%"
 
-:: Set BLA_VENDOR environment variable so CMake can find MKL
-set "BLA_VENDOR=Intel10_64lp"
-
-:: Explicitly set MKL library using the single-dynamic runtime (mkl_rt.lib)
-:: This is what's provided by mkl-devel on Windows defaults channel
-set "LAPACK_LIBRARIES=%LIBRARY_PREFIX%\lib\mkl_rt.lib"
+if "%blas_impl%"=="openblas" (
+    set "SS_BLAS=-DBLA_VENDOR=OpenBLAS"
+) else if "%blas_impl%"=="mkl" (
+    set "SS_BLAS=-DBLA_VENDOR=Intel10_64lp -DMAGMA_WITH_MKL:BOOL=ON -DMKLROOT=%LIBRARY_PREFIX% -DLAPACK_LIBRARIES=%LIBRARY_PREFIX%\lib\mkl_rt.lib"
+) else (
+    echo ERROR: blas_impl must be openblas or mkl, got "%blas_impl%"
+    exit /b 1
+)
 
 :: Must add --use-local-env to NVCC_FLAGS otherwise NVCC autoconfigs the host
 :: compiler to cl.exe instead of the full path. MSVC does not accept a
@@ -56,10 +56,7 @@ cmake %SRC_DIR% ^
   -DGPU_TARGET="%CUDA_ARCH_LIST%" ^
   -DMAGMA_ENABLE_CUDA:BOOL=ON ^
   -DUSE_FORTRAN:BOOL=OFF ^
-  -DMAGMA_WITH_MKL:BOOL=ON ^
-  -DMKLROOT=%MKLROOT% ^
-  -DBLA_VENDOR=%BLA_VENDOR% ^
-  -DLAPACK_LIBRARIES="%LAPACK_LIBRARIES%" ^
+  %SS_BLAS% ^
   -DCMAKE_CXX_STANDARD=17 ^
   -DCMAKE_CUDA_FLAGS="--use-local-env -Xfatbin -compress-all -Wno-deprecated-gpu-targets" ^
   -DCMAKE_CUDA_SEPARABLE_COMPILATION:BOOL=OFF

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -35,9 +35,9 @@ if errorlevel 1 exit /b 1
 set "CMAKE_PREFIX_PATH=%LIBRARY_PREFIX%;%CMAKE_PREFIX_PATH%"
 
 if "%blas_impl%"=="openblas" (
-    set "SS_BLAS=-DBLA_VENDOR=OpenBLAS"
+    set "BLAS_CONFIG=-DBLA_VENDOR=OpenBLAS -DLAPACK_LIBRARIES=%LIBRARY_PREFIX%\lib\libopenblas.lib"
 ) else if "%blas_impl%"=="mkl" (
-    set "SS_BLAS=-DBLA_VENDOR=Intel10_64lp -DMAGMA_WITH_MKL:BOOL=ON -DMKLROOT=%LIBRARY_PREFIX% -DLAPACK_LIBRARIES=%LIBRARY_PREFIX%\lib\mkl_rt.lib"
+    set "BLAS_CONFIG=-DBLA_VENDOR=Intel10_64lp -DMAGMA_WITH_MKL:BOOL=ON -DMKLROOT=%LIBRARY_PREFIX% -DLAPACK_LIBRARIES=%LIBRARY_PREFIX%\lib\mkl_rt.lib"
 ) else (
     echo ERROR: blas_impl must be openblas or mkl, got "%blas_impl%"
     exit /b 1
@@ -56,7 +56,7 @@ cmake %SRC_DIR% ^
   -DGPU_TARGET="%CUDA_ARCH_LIST%" ^
   -DMAGMA_ENABLE_CUDA:BOOL=ON ^
   -DUSE_FORTRAN:BOOL=OFF ^
-  %SS_BLAS% ^
+  %BLAS_CONFIG% ^
   -DCMAKE_CXX_STANDARD=17 ^
   -DCMAKE_CUDA_FLAGS="--use-local-env -Xfatbin -compress-all -Wno-deprecated-gpu-targets" ^
   -DCMAKE_CUDA_SEPARABLE_COMPILATION:BOOL=OFF

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -35,7 +35,7 @@ if errorlevel 1 exit /b 1
 set "CMAKE_PREFIX_PATH=%LIBRARY_PREFIX%;%CMAKE_PREFIX_PATH%"
 
 if "%blas_impl%"=="openblas" (
-    set "BLAS_CONFIG=-DBLA_VENDOR=OpenBLAS -DLAPACK_LIBRARIES=%LIBRARY_PREFIX%\lib\libopenblas.lib"
+    set "BLAS_CONFIG=-DBLA_VENDOR=OpenBLAS -DLAPACK_LIBRARIES=%LIBRARY_PREFIX%\lib\openblas.lib"
 ) else if "%blas_impl%"=="mkl" (
     set "BLAS_CONFIG=-DBLA_VENDOR=Intel10_64lp -DMAGMA_WITH_MKL:BOOL=ON -DMKLROOT=%LIBRARY_PREFIX% -DLAPACK_LIBRARIES=%LIBRARY_PREFIX%\lib\mkl_rt.lib"
 ) else (

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -40,12 +40,14 @@ export CXXFLAGS="${CXXFLAGS} -Wno-deprecated-declarations"
 mkdir build
 cd build
 
-CMAKE_EXTRA_ARGS=""
-if [[ "$(uname -m)" == "aarch64" ]]; then
+if [[ "${blas_impl}" == "openblas" ]]; then
   CMAKE_EXTRA_ARGS="-DBLA_VENDOR=OpenBLAS"
-else
+elif [[ "${blas_impl}" == "mkl" ]]; then
   export MKLROOT=$PREFIX
   CMAKE_EXTRA_ARGS="-DMAGMA_WITH_MKL:BOOL=ON -DMKLROOT=$MKLROOT -DBLA_VENDOR=Intel10_64lp"
+else
+  echo "ERROR: blas_impl must be openblas or mkl, got '${blas_impl}'"
+  exit 1
 fi
 
 cmake $SRC_DIR \

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -3,3 +3,7 @@ cuda_compiler_version:
   - 13.0
 mkl:
   - 2025
+
+blas_impl:
+  - mkl                        # [(x86 or x86_64) and not osx]
+  - openblas

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,7 @@ requirements:
     - intel-openmp {{ mkl }}  # [blas_impl == "mkl"]
     - mkl {{ mkl }}  # [blas_impl == "mkl"]
     - libopenblas  # [blas_impl == "openblas"]
-    - libgomp      # [blas_impl == "openblas"]
+    - libgomp      # [blas_impl == "openblas" and linux]
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,6 +39,7 @@ requirements:
     - mkl-include  # [blas_impl == "mkl"]
     - mkl-devel {{ mkl }}  # [blas_impl == "mkl" and win]
     - libopenblas  # [blas_impl == "openblas"]
+    - openblas-devel  # [blas_impl == "openblas" and win]
 
   run:
     - intel-openmp {{ mkl }}  # [blas_impl == "mkl"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,11 +13,11 @@ source:
     - patches/cuda13_clockrate.patch
 
 build:
-  number: 2
+  number: 3
   skip: true  # [not (win or linux)]
   overlinking_ignore_patterns:
-    - "lib/libgomp.so*"    # [aarch64]
-    - "lib/libmagma*.so*"  # [aarch64]
+    - "lib/libgomp.so*"    # [blas_impl == "openblas"]
+    - "lib/libmagma*.so*"  # [blas_impl == "openblas"]
 requirements:
   build:
     - {{ stdlib('c') }}
@@ -34,17 +34,17 @@ requirements:
     - libcublas-dev                                          # [cuda_compiler_version != "None"]
     - libcusparse-dev                                        # [cuda_compiler_version != "None"]
 
-    - intel-openmp {{ mkl }}  # [x86_64]
-    - mkl {{ mkl }}  # [x86_64]
-    - mkl-include  # [x86_64]
-    - mkl-devel {{ mkl }}  # [win]
-    - libopenblas  # [aarch64]
+    - intel-openmp {{ mkl }}  # [blas_impl == "mkl"]
+    - mkl {{ mkl }}  # [blas_impl == "mkl"]
+    - mkl-include  # [blas_impl == "mkl"]
+    - mkl-devel {{ mkl }}  # [blas_impl == "mkl" and win]
+    - libopenblas  # [blas_impl == "openblas"]
 
   run:
-    - intel-openmp {{ mkl }}  # [x86_64]
-    - mkl {{ mkl }}  # [x86_64]
-    - libopenblas  # [aarch64]
-    - libgomp  # [aarch64]
+    - intel-openmp {{ mkl }}  # [blas_impl == "mkl"]
+    - mkl {{ mkl }}  # [blas_impl == "mkl"]
+    - libopenblas  # [blas_impl == "openblas"]
+    - libgomp      # [blas_impl == "openblas"]
 
 test:
   commands:


### PR DESCRIPTION
magma rebuild with openblas windows variant

**Destination channel:** defaults

### Links

- [PKG-13584](https://anaconda.atlassian.net/browse/PKG-13584) 

### Explanation of changes:

- Bump build number
- Add openblas variant to build matrix for windows
- Handle dual mkl/openblas variants in bld.bat
- Use `blas_impl` for dependencies instead of fragile architecture 

## Notes

- 2.10 is available and #10 can be reviewed/released after this. 


[PKG-13584]: https://anaconda.atlassian.net/browse/PKG-13584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ