### PR TITLE
Use local tarbal.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+recipe/*.tar.gz binary
+recipe/*.tar.bz2 binary
+recipe/*.zip binary

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,8 @@ package:
   version: {{ version }}
 
 source:
-  url: file://{{ RECIPE_DIR }}/magma-{{ version }}.tar.gz
+  url: file://{{ RECIPE_DIR }}/magma-{{ version }}.tar.gz  # [not win]
+  url: file:///{{ RECIPE_DIR }}/magma-{{ version }}.tar.gz  # [win]
   sha256: ff77fd3726b3dfec3bfb55790b06480aa5cc384396c2db35c56fdae4a82c641c
   patches:
     - patches/thread_queue.patch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,9 +5,9 @@ package:
   version: {{ version }}
 
 source:
-   url: https://icl.cs.utk.edu/projectsfiles/magma/downloads/magma-{{ version }}.tar.gz
-   sha256: ff77fd3726b3dfec3bfb55790b06480aa5cc384396c2db35c56fdae4a82c641c
-   patches:
+  url: file://{{ RECIPE_DIR }}/magma-{{ version }}.tar.gz
+  sha256: ff77fd3726b3dfec3bfb55790b06480aa5cc384396c2db35c56fdae4a82c641c
+  patches:
     - patches/thread_queue.patch
     - patches/cmake_policy.patch
     - patches/cuda13_clockrate.patch


### PR DESCRIPTION
magma openblas windows variant

Same as #9 that was previously merged but never could be released due to PBP not being able to fetch the source. 

Github source doesn't include the pre-built CUDA files needed, given the PBP resources we have allocated, we've decided to just include the source in the recipe. 
