### PR TITLE
Explicitly include vcomp

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - build

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - build

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - patches/thread_queue.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [not (win or linux)]
   overlinking_ignore_patterns:
     - "lib/libgomp.so*"    # [blas_impl == "openblas"]
@@ -41,12 +41,14 @@ requirements:
     - mkl-devel {{ mkl }}  # [blas_impl == "mkl" and win]
     - libopenblas  # [blas_impl == "openblas"]
     - openblas-devel  # [blas_impl == "openblas" and win]
+    - vcomp14  # [blas_impl == "openblas" and (win and x86_64)]
 
   run:
     - intel-openmp {{ mkl }}  # [blas_impl == "mkl"]
     - mkl {{ mkl }}  # [blas_impl == "mkl"]
     - libopenblas  # [blas_impl == "openblas"]
     - libgomp      # [blas_impl == "openblas" and linux]
+    - vcomp14      # [blas_impl == "openblas" and (win and x86_64)]
 
 test:
   commands:


### PR DESCRIPTION
magma openmp rebuild

**Destination channel:** defaults

### Links

- [PKG-14722](https://anaconda.atlassian.net/browse/PKG-14722) 


### Explanation of changes:

- Bump build number
- Explicitly link to vcomp14 

## Note
The Github UI didn't update, the graph is green: https://package-build.anaconda.com/v1/graph/6bb4de50-69d6-4619-8b89-6dc9a0175a3e

[OpenMP usage Audit](https://docs.google.com/spreadsheets/d/1Pln3E1WKlhasfR5NNyT9juhXrcM_63bQpAZRHDjNHtc/edit?usp=sharing)

[PKG-14722]: https://anaconda.atlassian.net/browse/PKG-14722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ